### PR TITLE
41 Use Hwloc instead of CpuId in test/runtests.jl ...

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,12 +40,12 @@ julia = "1.9"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
 HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"
+Hwloc = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "CpuId", "FastCholesky", "JET", "Test", "ReTestItems", "StableRNGs", "HCubature"]
+test = ["Aqua", "BenchmarkTools", "FastCholesky", "Hwloc", "JET", "Test", "ReTestItems", "StableRNGs", "HCubature"]

--- a/test/algebra/arrowheadmatrix_tests.jl
+++ b/test/algebra/arrowheadmatrix_tests.jl
@@ -148,7 +148,7 @@ end
         # our implementation is at least k times faster on average
         k = @static if VERSION < v"1.12"
             n ÷ 3
-        else 
+        else
             n ÷ 5
         end
 
@@ -186,7 +186,7 @@ end
         # our implementation is at least k times faster on average
         k = @static if VERSION < v"1.12"
             n ÷ 3
-        else 
+        else
             n ÷ 5
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Aqua, CpuId, ReTestItems, BayesBase
+using Aqua, Hwloc, ReTestItems, BayesBase
 
 # `ambiguities = false` - there are quite some ambiguities, but these should be normal and should not be encountered under normal circumstances
 # `piracy = false` - we extend/add some of the methods to the objects defined in the Distributions.jl
@@ -9,9 +9,10 @@ Aqua.test_all(
     deps_compat=(; check_extras=false, check_weakdeps=true),
 )
 
-nthreads = max(cputhreads(), 1)
-ncores = max(cpucores(), 1)
+ncores   = max(Hwloc.num_physical_cores(), 1)
+nthreads = max(Hwloc.num_virtual_cores(), 1)
+threads_per_core = max(Int(floor(nthreads / ncores)), 1)
 
 runtests(
-    BayesBase; nworkers=ncores, nworker_threads=Int(nthreads / ncores), memory_threshold=1.0
+    BayesBase; nworkers=ncores, nworker_threads=threads_per_core, memory_threshold=1.0
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,10 +9,8 @@ Aqua.test_all(
     deps_compat=(; check_extras=false, check_weakdeps=true),
 )
 
-ncores   = max(Hwloc.num_physical_cores(), 1)
+ncores = max(Hwloc.num_physical_cores(), 1)
 nthreads = max(Hwloc.num_virtual_cores(), 1)
 threads_per_core = max(Int(floor(nthreads / ncores)), 1)
 
-runtests(
-    BayesBase; nworkers=ncores, nworker_threads=threads_per_core, memory_threshold=1.0
-)
+runtests(BayesBase; nworkers=ncores, nworker_threads=threads_per_core, memory_threshold=1.0)


### PR DESCRIPTION
... for cross-platform/architecture-agnostic detection of cores/threads.

Does resolve #41

Works for Linux, Windows,  and OS X - and Intel, AMD, ...

CI actions should confirm that