### PR TITLE
PR: Preserve the sign of infinity when converting `CountingReal` to `float`

### DIFF
--- a/src/statsfuns.jl
+++ b/src/statsfuns.jl
@@ -314,7 +314,15 @@ function Base.convert(::Type{CountingReal{T}}, v::CountingReal{R}) where {T<:Rea
     return CountingReal{T}(convert(T, value(v)), infinities(v))
 end
 
-Base.float(a::CountingReal{T}) where {T} = isfinite(a) ? value(a) : convert(T, Inf)
+function Base.float(a::CountingReal{T}) where {T}
+    if isfinite(a)
+        return value(a)
+    elseif infinities(a) < 0 || value(a) < 0
+        return -convert(T, Inf)
+    else
+        return convert(T, Inf)
+    end
+end
 Base.zero(::Type{CountingReal{T}}) where {T<:Real} = CountingReal(zero(T))
 
 function Base.promote_rule(::Type{CountingReal{T1}}, ::Type{T2}) where {T1<:Real,T2<:Real}


### PR DESCRIPTION
- **Closes:** `issues/issue-01-float-minusinfinity-sign.md`
- **Branch (local draft):** `fix/float-minusinfinity-sign`

## Summary

`float(::CountingReal)` currently collapses every non-finite `CountingReal` to
`+Inf`, so a genuine minus infinity is silently returned as `+Inf`. This PR
returns the sign-correct infinity based on the `infinities` counter (and on an
infinite `value`), and adds regression tests.

## Change

`src/statsfuns.jl:317`

```diff
-Base.float(a::CountingReal{T}) where {T} = isfinite(a) ? value(a) : convert(T, Inf)
+function Base.float(a::CountingReal{T}) where {T}
+    if isfinite(a)
+        return value(a)
+    elseif infinities(a) < 0 || value(a) < 0
+        return -convert(T, Inf)
+    else
+        return convert(T, Inf)
+    end
+end
```

`test/statsfuns_tests.jl` (in the `CountingReal` testitem):

```julia
@test float(BayesBase.MinusInfinity(Float64)) == -Inf
@test float(BayesBase.Infinity(Float64)) == Inf
@test float(BayesBase.CountingReal(Float64, 1)) == Inf
@test float(BayesBase.CountingReal(Float64, -1)) == -Inf
```

## Why this is correct

`Infinity(T)` = `(0, +1)`, `MinusInfinity(T)` = `(0, -1)`. The sign of
`infinities` encodes the sign of the infinity, exactly as addition/negation of
`CountingReal` already use it (`src/statsfuns.jl:280-306`). Falling back to the
sign of `value` handles the case where the *value* itself is an actual `±Inf`.

## Verification

1. `julia --project=. -e 'using BayesBase; @assert float(BayesBase.MinusInfinity(Float64)) == -Inf'`
2. `julia --project=. -e 'using Pkg; Pkg.test()'` (existing suite green; new tests pass)

Closes #54
